### PR TITLE
Add support for pausing / resuming windups

### DIFF
--- a/src/react/WindupChildren.tsx
+++ b/src/react/WindupChildren.tsx
@@ -18,6 +18,16 @@ const WindupContext = React.createContext({
       "Tried to use the useSkip hook outside of a WindupChildren component!!"
     );
   },
+  pause: () => {
+    console.warn(
+      "Tried to use the usePause hook outside of a WindupChildren component!!"
+    );
+  },
+  resume: () => {
+    console.warn(
+      "Tried to use the useResume hook outside of a WindupChildren component!!"
+    );
+  },
   rewind: () => {
     console.warn(
       "Tried to use the useRewind hook outside of a WindupChildren component!"
@@ -29,6 +39,16 @@ const WindupContext = React.createContext({
 export function useSkip() {
   const { skip } = React.useContext(WindupContext);
   return skip;
+}
+
+export function usePause() {
+  const { pause } = React.useContext(WindupContext);
+  return pause;
+}
+
+export function useResume() {
+  const { resume } = React.useContext(WindupContext);
+  return resume;
 }
 
 export function useRewind() {
@@ -174,6 +194,7 @@ function reduceWindupArgs(
 type WindupChildrenProps = {
   onFinished?: () => void;
   skipped?: boolean;
+  isPaused?: boolean;
 };
 
 function buildKeyString(children: React.ReactNode): string {
@@ -215,7 +236,8 @@ function useChildrenMemo<T>(factory: () => T, children: React.ReactNode) {
 const WindupChildren: React.FC<WindupChildrenProps> = ({
   children,
   onFinished,
-  skipped
+  skipped,
+  isPaused = false
 }) => {
   const windupInit = useChildrenMemo(() => {
     return newWindup<string, ChildrenMetadata>(
@@ -224,15 +246,28 @@ const WindupChildren: React.FC<WindupChildrenProps> = ({
     );
   }, children);
 
-  const { windup, skip, rewind, isFinished } = useWindup(windupInit, {
-    onFinished,
-    skipped
-  });
+  const { windup, skip, pause, resume, rewind, isFinished } = useWindup(
+    windupInit,
+    {
+      onFinished,
+      skipped
+    }
+  );
+
+  React.useEffect(() => {
+    if (isPaused === true) {
+      pause();
+    } else {
+      resume();
+    }
+  }, [isPaused, pause, resume]);
 
   return (
     <WindupContext.Provider
       value={{
         skip,
+        pause,
+        resume,
         rewind,
         isFinished
       }}

--- a/src/react/useWindup.ts
+++ b/src/react/useWindup.ts
@@ -120,7 +120,7 @@ export default function useWindup<M extends HookMetadata>(
         nextCharAtRef.current ?? 0 - Date.now()
       );
     }
-  }, [isPausedRef, timeoutRef, nextCharAtRef, pauseDelayRemainingRef]);
+  }, []);
 
   const resume = React.useCallback(() => {
     if (isPausedRef.current !== true) {
@@ -133,7 +133,7 @@ export default function useWindup<M extends HookMetadata>(
         dispatch({ type: "next" });
       }, pauseDelayRemainingRef.current ?? 0);
     }
-  }, [isPausedRef, windupIsFinished, pauseDelayRemainingRef]);
+  }, [windupIsFinished]);
 
   const rewind = React.useCallback(() => {
     if (timeoutRef.current) {

--- a/src/react/useWindup.ts
+++ b/src/react/useWindup.ts
@@ -111,9 +111,9 @@ export default function useWindup<M extends HookMetadata>(
       return;
     }
 
-    if (timeoutRef.current) {
-      isPausedRef.current = true;
+    isPausedRef.current = true;
 
+    if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
       pauseDelayRemainingRef.current = Math.max(
         0,
@@ -128,9 +128,8 @@ export default function useWindup<M extends HookMetadata>(
     }
 
     if (!windupIsFinished) {
-      isPausedRef.current = false;
-
       setTimeout(() => {
+        isPausedRef.current = false;
         dispatch({ type: "next" });
       }, pauseDelayRemainingRef.current ?? 0);
     }
@@ -202,9 +201,13 @@ export default function useWindup<M extends HookMetadata>(
       const pace = lastEl ? getPace(lastEl, nextEl) : 0;
 
       nextCharAtRef.current = Date.now() + pace;
-      timeoutRef.current = setTimeout(() => {
-        dispatch({ type: "next" });
-      }, pace);
+
+      if (isPausedRef.current !== true) {
+        timeoutRef.current = setTimeout(() => {
+          dispatch({ type: "next" });
+        }, pace);
+      }
+
       return () => {
         if (timeoutRef.current) {
           clearTimeout(timeoutRef.current);

--- a/src/react/useWindupString.ts
+++ b/src/react/useWindupString.ts
@@ -21,6 +21,8 @@ export default function useWindupString(
   string,
   {
     skip: () => void;
+    pause: () => void;
+    resume: () => void;
     rewind: () => void;
     isFinished: boolean;
   }
@@ -31,10 +33,13 @@ export default function useWindupString(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [text]);
 
-  const { windup, skip, rewind, isFinished } = useWindup(windupInit, options);
+  const { windup, skip, pause, resume, rewind, isFinished } = useWindup(
+    windupInit,
+    options
+  );
 
   const rendered = renderStringWindup(windup);
   React.useDebugValue(rendered);
 
-  return [rendered, { skip, rewind, isFinished }];
+  return [rendered, { skip, pause, resume, rewind, isFinished }];
 }


### PR DESCRIPTION
Hello! I was trying to pause / resume my windup based on interactions with footnotes embedded in the text (see Loom). Thought I would contrib my work so far.

I hear you're working on a new rendering mechanism (backwards and forwards! so cool!!) so no worries if this shan't land. If you're into it please advise re: how to test and/or document this for release.

https://www.loom.com/share/d0e2f1c980d44bdc9bd49d15208d676c