### PR TITLE
Add explicit types for children in React.FC

### DIFF
--- a/src/react/CharWrapper.tsx
+++ b/src/react/CharWrapper.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 type CharWrapperProps = {
+  children: React.ReactNode;
   element: React.ElementType;
 };
 

--- a/src/react/Linebreaker.tsx
+++ b/src/react/Linebreaker.tsx
@@ -92,6 +92,7 @@ export function StyledText({ children }: StyledTextProps) {
 }
 
 type LinebreakerProps = {
+  children: React.ReactNode;
   fontStyle: string;
   width: number;
 };

--- a/src/react/OnChar.tsx
+++ b/src/react/OnChar.tsx
@@ -8,6 +8,7 @@ import {
 import { HookMetadata } from "./useWindup";
 
 type OnCharProps = {
+  children: React.ReactNode;
   fn: (char: string) => void;
 };
 

--- a/src/react/Pace.tsx
+++ b/src/react/Pace.tsx
@@ -38,7 +38,7 @@ export function defaultGetPace(
   }
 }
 
-const Pace: React.FC<PaceProps> = ({ children }) => {
+const Pace: React.FC<React.PropsWithChildren<PaceProps>> = ({ children }) => {
   return <>{children}</>;
 };
 

--- a/src/react/WindupChildren.tsx
+++ b/src/react/WindupChildren.tsx
@@ -172,6 +172,7 @@ function reduceWindupArgs(
 }
 
 type WindupChildrenProps = {
+  children: React.ReactNode;
   onFinished?: () => void;
   skipped?: boolean;
 };


### PR DESCRIPTION
Hi, this issue is outlined in #43, where the implicit children in `React.FC<T>` were removed in React 18. 
I tested this on a React 18 site and the type issues seem to be fixed.

I'm pretty sure the implicit type of children in `React.FC<T>` was `React.ReactNode` so this shouldn't introduce any API changes or break compatibility with previous React versions ^_^

fixes #43 