### PR TITLE
Fix computation for `pauseDelayRemaining`

### DIFF
--- a/src/react/useWindup.ts
+++ b/src/react/useWindup.ts
@@ -117,7 +117,7 @@ export default function useWindup<M extends HookMetadata>(
       clearTimeout(timeoutRef.current);
       pauseDelayRemainingRef.current = Math.max(
         0,
-        nextCharAtRef.current ?? 0 - Date.now()
+        (nextCharAtRef.current ?? 0) - Date.now()
       );
     }
   }, []);


### PR DESCRIPTION
Sorry for the inconvenience! Turns out that when I fixed the _other_ issue I also managed to brick something 😅

These missing parens transpiled to:
```js
(nextCharAtRef.current != null) ? nextCharAtRef : 0 - Date.now()`
```

Which executes differently from:
```js
((nextCharAtRef.current != null) ? nextCharAtRef : 0) - Date.now()`
```

The error manifested as very-very-long timeouts being set before printing the next character whenever `resume` was called (e.g. scheduling for `Date.now()` ms in the future, vs. ~23ms)